### PR TITLE
Update the appVersion to match the docker image version

### DIFF
--- a/charts/layer-zero/Chart.yaml
+++ b/charts/layer-zero/Chart.yaml
@@ -4,6 +4,7 @@ name: "layer-zero"
 description: "Helm Chart for LayerZero"
 type: "application"
 version: "1.3.0"
+# renovate: image=us-east1-docker.pkg.dev/lz-docker/gasolina/gasolina
 appVersion: "1.1.26"
 dependencies:
   - name: "common"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "fileMatch": [
+        "(^|/)Chart\\.yaml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate: image=(?<depName>.*?)\\s+appVersion:\\s*[\"']?(?<currentValue>[\\w+\\.\\-]*)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Currently you have to adapt the "appVersion" in `Chart.yaml` every time, when renovate updates the primary docker image, which is annoying and can lead to inconsistency. Therefore this PR updates the Chart.yaml based on the docker image version  