### PR TITLE
Fix layer-zero deployment

### DIFF
--- a/charts/layer-zero/Chart.yaml
+++ b/charts/layer-zero/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: "v2"
 name: "layer-zero"
 description: "Helm Chart for LayerZero"
 type: "application"
-version: "2.0.0"
+version: "2.0.1"
 # renovate: image=us-east1-docker.pkg.dev/lz-docker/gasolina/gasolina
 appVersion: "1.2.2"
 dependencies:

--- a/charts/layer-zero/templates/deployment.yaml
+++ b/charts/layer-zero/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
               mountPath: "{{ include "layer-zero.secretVolumePath" . }}/"
             - name: {{ include "layer-zero.configVolumeName" . }}
               mountPath: "{{ include "layer-zero.configVolumePath" . }}/"
+            - name: "tmp"
+              mountPath: "/tmp"
         {{- if .Values.diagnosticMode.enabled }}
           command: ["sleep"]
           args: ["infinity"]
@@ -70,7 +72,7 @@ spec:
           args:
             - "/bin/bash"
             - "-c"
-            - "NODE_OPTIONS=--max-old-space-size=$MAX_OLD_SPACE_SIZE apps/gasolina/node_modules/.bin/ts-node-transpile-only apps/gasolina/src/index.ts"
+            - "NODE_OPTIONS=--max-old-space-size=$MAX_OLD_SPACE_SIZE migrated/offchain-monorepo/apps/gasolina/node_modules/.bin/tsx migrated/offchain-monorepo/apps/gasolina/src/index.ts"
           {{- range .Values.extraArgs }}
             {{ . }}
           {{- end }}
@@ -152,4 +154,6 @@ spec:
                 path: "quorum-strategy.json"
               - key: "wallets.json"
                 path: "wallets.json"
+        - name: "tmp"
+          emptyDir: {}
 ...


### PR DESCRIPTION
## Summary

Image tag `1.2.2` changed how the application is started which lead to two different issues:

1. NODE_OPTIONS changed since the app is now invoked via tsx
2. tsx tries to write to `tmp` folder which by default belongs to root filesystem which is forbidden via our chart security settings
    - Solution: we add a `/tmp` mount dir which is writable